### PR TITLE
Add more tests and remove optional Bevy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4016,6 +4016,7 @@ dependencies = [
  "rodio",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -4905,6 +4906,19 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix 1.0.7",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "termcolor"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,20 @@
+
 [package]
 name = "plop"
 version = "0.1.0"
 edition = "2024"
 
+[lib]
+path = "src/lib.rs"
+
 [dependencies]
-bevy = { version = "0.16" }
-bevy_egui = "0.34" 
+bevy = "0.16"
+bevy_egui = "0.34"
 egui = { version = "0.31", features = ["persistence"]}
-serde = { version = "1.0", features = ["derive"] } 
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-rodio = "0.20" 
+rodio = "0.20"
 dirs = "5.0"
+
+[dev-dependencies]
+tempfile = "3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,132 @@
+use bevy::prelude::Component;
+use egui::{Color32, Pos2, Rect, Vec2};
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, path::PathBuf};
+
+/// Data for a single Post-It note
+#[derive(Component, Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct NoteData {
+    pub id: u64,
+    pub text: String,
+    pub pos: Pos2,
+    pub size: Vec2,
+    pub color: Color32,
+}
+
+/// Virtual board containing multiple notes
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct Board {
+    pub id: u64,
+    pub name: String,
+    pub background: Color32,
+    pub notes: Vec<NoteData>,
+    pub scene_rect: Rect,
+}
+
+/// Global application state
+#[derive(Serialize, Deserialize, Debug, Default, PartialEq)]
+pub struct AppState {
+    pub boards: HashMap<u64, Board>,
+    pub current_board: Option<u64>,
+    pub next_note_id: u64,
+    pub next_board_id: u64,
+}
+
+impl AppState {
+    /// Save to JSON file
+    pub fn save_to_file(&self, path: &PathBuf) {
+        if let Ok(json) = serde_json::to_string_pretty(self) {
+            let _ = std::fs::write(path, json);
+        }
+    }
+
+    /// Load from JSON file
+    pub fn load_from_file(path: &PathBuf) -> Self {
+        if let Ok(data) = std::fs::read_to_string(path) {
+            if let Ok(state) = serde_json::from_str(&data) {
+                return state;
+            }
+        }
+        AppState::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::NamedTempFile;
+    use std::fs;
+
+    #[test]
+    fn save_and_load_roundtrip() {
+        let mut state = AppState::default();
+        let board = Board {
+            id: 1,
+            name: "Test".into(),
+            background: Color32::WHITE,
+            notes: vec![NoteData {
+                id: 1,
+                text: "hi".into(),
+                pos: Pos2 { x: 1.0, y: 2.0 },
+                size: Vec2 { x: 10.0, y: 10.0 },
+                color: Color32::BLACK,
+            }],
+            scene_rect: Rect::from_min_size(Pos2::ZERO, Vec2::ZERO),
+        };
+        state.current_board = Some(1);
+        state.boards.insert(1, board);
+
+        let file = NamedTempFile::new().unwrap();
+        let path = file.path().to_path_buf();
+        state.save_to_file(&path);
+        let loaded = AppState::load_from_file(&path);
+        assert_eq!(state, loaded);
+    }
+
+    #[test]
+    fn load_missing_file_returns_default() {
+        let file = NamedTempFile::new().unwrap();
+        let path = file.path().to_path_buf();
+        drop(file); // delete immediately
+        let loaded = AppState::load_from_file(&path);
+        assert_eq!(loaded, AppState::default());
+    }
+
+    #[test]
+    fn load_invalid_json_returns_default() {
+        let file = NamedTempFile::new().unwrap();
+        let path = file.path().to_path_buf();
+        fs::write(&path, "not valid json").unwrap();
+        let loaded = AppState::load_from_file(&path);
+        assert_eq!(loaded, AppState::default());
+    }
+
+    #[test]
+    fn edited_note_persists_after_save_load() {
+        let mut state = AppState::default();
+        let mut board = Board {
+            id: 1,
+            name: "Test".into(),
+            background: Color32::WHITE,
+            notes: vec![NoteData {
+                id: 1,
+                text: "hello".into(),
+                pos: Pos2 { x: 0.0, y: 0.0 },
+                size: Vec2 { x: 10.0, y: 10.0 },
+                color: Color32::BLACK,
+            }],
+            scene_rect: Rect::from_min_size(Pos2::ZERO, Vec2::ZERO),
+        };
+        board.notes[0].text = "edited".into();
+        state.boards.insert(1, board.clone());
+        state.current_board = Some(1);
+
+        let file = NamedTempFile::new().unwrap();
+        let path = file.path().to_path_buf();
+        state.save_to_file(&path);
+        let loaded = AppState::load_from_file(&path);
+        assert_eq!(loaded.boards.get(&1).unwrap().notes[0].text, "edited");
+        assert_eq!(loaded, state);
+    }
+}
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,21 +1,8 @@
 use bevy::prelude::*;
 use bevy_egui::EguiContexts;
 use egui::{Color32, Pos2, Rect, Vec2};
-use serde::{Deserialize, Serialize};
-use std::{
-    collections::HashMap,
-    path::PathBuf,
-};
-
-/// Data for a single Post-It note
-#[derive(Component, Serialize, Deserialize, Debug, Clone)]
-struct NoteData {
-    id: u64,
-    text: String,
-    pos: Pos2,
-    size: Vec2,
-    color: Color32,
-}
+use std::path::PathBuf;
+use plop::{AppState, Board, NoteData};
 
 /// Runtime UI state for a note
 #[derive(Component)]
@@ -37,44 +24,6 @@ impl Default for NoteUi {
 /// Tag component to associate a note entity with a board
 #[derive(Component)]
 struct BelongsToBoard(u64);
-
-/// Virtual board containing multiple notes
-#[derive(Serialize, Deserialize, Debug, Clone)]
-struct Board {
-    id: u64,
-    name: String,
-    background: Color32,
-    notes: Vec<NoteData>,
-    scene_rect: Rect,
-}
-
-/// Global application state
-#[derive(Serialize, Deserialize, Debug, Default)]
-struct AppState {
-    boards: HashMap<u64, Board>,
-    current_board: Option<u64>,
-    next_note_id: u64,
-    next_board_id: u64,
-}
-
-impl AppState {
-    /// Save to JSON file
-    fn save_to_file(&self, path: &PathBuf) {
-        if let Ok(json) = serde_json::to_string_pretty(self) {
-            let _ = std::fs::write(path, json);
-        }
-    }
-
-    /// Load from JSON file
-    fn load_from_file(path: &PathBuf) -> Self {
-        if let Ok(data) = std::fs::read_to_string(path) {
-            if let Ok(state) = serde_json::from_str(&data) {
-                return state;
-            }
-        }
-        AppState::default()
-    }
-}
 
 // Audio resource to play the plop sound
 #[derive(Resource)]


### PR DESCRIPTION
## Summary
- make Bevy required in `Cargo.toml`
- always derive `Component` for library structs
- add multiple persistence tests for `AppState`

## Testing
- `cargo test --lib -- --nocapture`
- `cargo fmt -- --check` *(failed: rustfmt missing)*

------
https://chatgpt.com/codex/tasks/task_b_684160e07764832f8166b50a596a5f9d